### PR TITLE
Strider: Create, Copy, Delete, Move

### DIFF
--- a/default-plugins/strider/src/file_list_view.rs
+++ b/default-plugins/strider/src/file_list_view.rs
@@ -171,16 +171,8 @@ impl FsEntry {
         }
     }
     pub fn get_pathbuf_without_root_prefix(&self) -> PathBuf {
-        match self {
-            FsEntry::Dir(p) => p
-                .strip_prefix(ROOT)
-                .map(|p| p.to_path_buf())
-                .unwrap_or_else(|_| p.clone()),
-            FsEntry::File(p, _) => p
-                .strip_prefix(ROOT)
-                .map(|p| p.to_path_buf())
-                .unwrap_or_else(|_| p.clone()),
-        }
+        let p = self.get_pathbuf();
+        p.strip_prefix(ROOT).map(|p| p.to_path_buf()).unwrap_or_else(|_| p.clone())
     }
 
     pub fn is_hidden_file(&self) -> bool {

--- a/default-plugins/strider/src/file_list_view.rs
+++ b/default-plugins/strider/src/file_list_view.rs
@@ -165,6 +165,11 @@ impl FsEntry {
             FsEntry::File(_, size) => Some(*size),
         }
     }
+    pub fn get_pathbuf(&self) -> PathBuf {
+        match self {
+            FsEntry::Dir(path) | FsEntry::File(path, _) => path.clone()
+        }
+    }
     pub fn get_pathbuf_without_root_prefix(&self) -> PathBuf {
         match self {
             FsEntry::Dir(p) => p

--- a/default-plugins/strider/src/file_list_view.rs
+++ b/default-plugins/strider/src/file_list_view.rs
@@ -167,12 +167,14 @@ impl FsEntry {
     }
     pub fn get_pathbuf(&self) -> PathBuf {
         match self {
-            FsEntry::Dir(path) | FsEntry::File(path, _) => path.clone()
+            FsEntry::Dir(path) | FsEntry::File(path, _) => path.clone(),
         }
     }
     pub fn get_pathbuf_without_root_prefix(&self) -> PathBuf {
         let p = self.get_pathbuf();
-        p.strip_prefix(ROOT).map(|p| p.to_path_buf()).unwrap_or_else(|_| p.clone())
+        p.strip_prefix(ROOT)
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|_| p.clone())
     }
 
     pub fn is_hidden_file(&self) -> bool {

--- a/default-plugins/strider/src/file_list_view.rs
+++ b/default-plugins/strider/src/file_list_view.rs
@@ -161,7 +161,7 @@ impl FsEntry {
     }
     pub fn size(&self) -> Option<u64> {
         match self {
-            FsEntry::Dir(p) => None,
+            FsEntry::Dir(_) => None,
             FsEntry::File(_, size) => Some(*size),
         }
     }

--- a/default-plugins/strider/src/main.rs
+++ b/default-plugins/strider/src/main.rs
@@ -59,7 +59,6 @@ impl ZellijPlugin for State {
     }
 
     fn update(&mut self, event: Event) -> bool {
-        // TODO: Only run this if the event is a key
         match self.mode {
             state::Mode::Keybinds => {
                 self.mode = state::Mode::Normal;
@@ -100,11 +99,7 @@ impl ZellijPlugin for State {
                 },
                 Key::Char('\n') => match self.mode {
                     state::Mode::Normal | state::Mode::Searching => self.open_selected_path(),
-                    state::Mode::Create | state::Mode::Copy | state::Mode::Delete | state::Mode::Move => {
-                        //TODO: Remove this when done testing
-                        should_render = true;
-                        self.handle_file_manipulation();
-                    },
+                    state::Mode::Create | state::Mode::Copy | state::Mode::Delete | state::Mode::Move => self.handle_file_manipulation(),
                     _ => {}
                 },
                 Key::Right | Key::BackTab => {

--- a/default-plugins/strider/src/main.rs
+++ b/default-plugins/strider/src/main.rs
@@ -99,8 +99,11 @@ impl ZellijPlugin for State {
                 },
                 Key::Char('\n') => match self.mode {
                     state::Mode::Normal | state::Mode::Searching => self.open_selected_path(),
-                    state::Mode::Create | state::Mode::Copy | state::Mode::Delete | state::Mode::Move => self.handle_file_manipulation(),
-                    _ => {}
+                    state::Mode::Create
+                    | state::Mode::Copy
+                    | state::Mode::Delete
+                    | state::Mode::Move => self.handle_file_manipulation(),
+                    _ => {},
                 },
                 Key::Right | Key::BackTab => {
                     self.traverse_dir();
@@ -133,12 +136,12 @@ impl ZellijPlugin for State {
                     should_render = true;
                     self.move_entry_to_search();
                     self.mode = state::Mode::Copy
-                }
+                },
                 Key::Ctrl('a') => {
                     should_render = true;
                     self.search_term = "".to_string();
                     self.mode = state::Mode::Create;
-                }
+                },
                 _ => (),
             },
             Event::Mouse(mouse_event) => match mouse_event {

--- a/default-plugins/strider/src/main.rs
+++ b/default-plugins/strider/src/main.rs
@@ -58,6 +58,12 @@ impl ZellijPlugin for State {
     }
 
     fn update(&mut self, event: Event) -> bool {
+        if self.showing_keybinds {
+            // Any key will hide the keybinds
+            self.showing_keybinds = false;
+            return true;
+        }
+
         let mut should_render = false;
         match event {
             Event::FileSystemUpdate(paths) => {
@@ -147,8 +153,15 @@ impl ZellijPlugin for State {
     }
 
     fn render(&mut self, rows: usize, cols: usize) {
+        if self.showing_keybinds {
+            render_instruction_line(cols);
+            render_instruction_tip(rows, cols);
+            return;
+        }
+
         self.current_rows = Some(rows);
         let rows_for_list = rows.saturating_sub(6);
+
         render_search_term(&self.search_term);
         render_current_path(
             &self.initial_cwd,
@@ -162,10 +175,6 @@ impl ZellijPlugin for State {
         } else {
             self.file_list_view.render(rows_for_list, cols);
         }
-        if self.showing_keybinds {
-            render_instruction_line(rows, cols);
-        } else {
-            render_instruction_tip(rows, cols);
-        }
+        render_instruction_tip(rows, cols);
     }
 }

--- a/default-plugins/strider/src/main.rs
+++ b/default-plugins/strider/src/main.rs
@@ -100,7 +100,11 @@ impl ZellijPlugin for State {
                 },
                 Key::Char('\n') => match self.mode {
                     state::Mode::Normal | state::Mode::Searching => self.open_selected_path(),
-                    state::Mode::Create | state::Mode::Copy | state::Mode::Delete | state::Mode::Move => self.handle_file_manipulation(),
+                    state::Mode::Create | state::Mode::Copy | state::Mode::Delete | state::Mode::Move => {
+                        //TODO: Remove this when done testing
+                        should_render = true;
+                        self.handle_file_manipulation();
+                    },
                     _ => {}
                 },
                 Key::Right | Key::BackTab => {

--- a/default-plugins/strider/src/main.rs
+++ b/default-plugins/strider/src/main.rs
@@ -141,7 +141,7 @@ impl ZellijPlugin for State {
                 }
                 Key::Ctrl('a') => {
                     should_render = true;
-                    self.move_entry_to_search();
+                    self.search_term = "".to_string();
                     self.mode = state::Mode::Create;
                 }
                 _ => (),

--- a/default-plugins/strider/src/main.rs
+++ b/default-plugins/strider/src/main.rs
@@ -4,7 +4,7 @@ mod shared;
 mod state;
 
 use crate::file_list_view::FsEntry;
-use shared::{render_current_path, render_instruction_line, render_search_term};
+use shared::{render_current_path, render_instruction_tip, render_instruction_line, render_search_term};
 use state::{refresh_directory, State};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -21,6 +21,7 @@ impl ZellijPlugin for State {
             .map(|v| v == "true")
             .unwrap_or(false);
         self.hide_hidden_files = !show_hidden_files;
+        self.showing_keybinds = false;
         self.close_on_selection = configuration
             .get("close_on_selection")
             .map(|v| v == "true")
@@ -103,6 +104,10 @@ impl ZellijPlugin for State {
                     self.toggle_hidden_files();
                     refresh_directory(&self.file_list_view.path);
                 },
+                Key::Ctrl('h') => {
+                    should_render = true;
+                    self.showing_keybinds = !self.showing_keybinds;
+                }
                 _ => (),
             },
             Event::Mouse(mouse_event) => match mouse_event {
@@ -157,6 +162,10 @@ impl ZellijPlugin for State {
         } else {
             self.file_list_view.render(rows_for_list, cols);
         }
-        render_instruction_line(rows, cols);
+        if self.showing_keybinds {
+            render_instruction_line(rows, cols);
+        } else {
+            render_instruction_tip(rows, cols);
+        }
     }
 }

--- a/default-plugins/strider/src/main.rs
+++ b/default-plugins/strider/src/main.rs
@@ -77,7 +77,9 @@ impl ZellijPlugin for State {
                 Key::Esc | Key::Ctrl('c') => self.clear_search_term_or_descend(),
                 Key::Up => self.move_selection_up(),
                 Key::Down => self.move_selection_down(),
-                Key::Char('\n') if self.handling_filepick_request_from.is_some() => self.send_filepick_response(),
+                Key::Char('\n') if self.handling_filepick_request_from.is_some() => {
+                    self.send_filepick_response()
+                },
                 Key::Char('\n') => match self.mode {
                     state::Mode::Normal | state::Mode::Searching => self.open_selected_path(),
                     state::Mode::Create

--- a/default-plugins/strider/src/shared.rs
+++ b/default-plugins/strider/src/shared.rs
@@ -10,26 +10,19 @@ pub fn render_instruction_tip(y: usize, max_cols: usize) {
     print_text_with_coordinates(text, 0, y, Some(max_cols), None);
 }
 
-pub fn render_instruction_line(y: usize, max_cols: usize) {
-    if max_cols > 78 {
-        let text = "Help: go back with <Ctrl c>, go to root with /, <Ctrl e> - toggle hidden files";
-        let text = Text::new(text)
-            .color_range(3, 19..27)
-            .color_range(3, 45..46)
-            .color_range(3, 48..56);
-        print_text_with_coordinates(text, 0, y, Some(max_cols), None);
-    } else if max_cols > 56 {
-        let text = "Help: <Ctrl c> - back, / - root, <Ctrl e> - hidden files";
-        let text = Text::new(text)
-            .color_range(3, 6..14)
-            .color_range(3, 23..24)
-            .color_range(3, 33..41);
-        print_text_with_coordinates(text, 0, y, Some(max_cols), None);
-    } else if max_cols > 25 {
-        let text = "<Ctrl c> - back, / - root";
-        let text = Text::new(text).color_range(3, ..8).color_range(3, 17..18);
-        print_text_with_coordinates(text, 0, y, Some(max_cols), None);
-    }
+pub fn render_instruction_line(max_cols: usize) {
+    let text = Text::new("Go back <Ctrl c>")
+        .color_range(3, 13..20);
+    print_text_with_coordinates(text, 0, 0, Some(max_cols), None);
+
+
+    let text = Text::new("Go to root /")
+        .color_range(3, 3..5);
+    print_text_with_coordinates(text, 0, 1, Some(max_cols), None);
+
+    let text = Text::new("Toggle hidden files <Ctrl e>")
+        .color_range(3, 3..5);
+    print_text_with_coordinates(text, 0, 2, Some(max_cols), None);
 }
 
 pub fn render_list_tip(y: usize, max_cols: usize) {

--- a/default-plugins/strider/src/shared.rs
+++ b/default-plugins/strider/src/shared.rs
@@ -82,7 +82,7 @@ pub fn render_instruction_line(max_cols: usize) {
         HelpTextSize::Medium => "copy",
         _ => ""
     };
-    render_help_text(bind, desc, max_cols, 4);
+    render_help_text(bind, desc, max_cols, 5);
 
     let bind = "<Ctrl a>";
     let desc = match text_size {
@@ -90,7 +90,7 @@ pub fn render_instruction_line(max_cols: usize) {
         HelpTextSize::Medium => "create",
         _ => ""
     };
-    render_help_text(bind, desc, max_cols, 4);
+    render_help_text(bind, desc, max_cols, 6);
 }
 
 pub fn render_list_tip(y: usize, max_cols: usize) {

--- a/default-plugins/strider/src/shared.rs
+++ b/default-plugins/strider/src/shared.rs
@@ -1,20 +1,21 @@
+use crate::state::Mode;
 use std::path::PathBuf;
 use unicode_width::UnicodeWidthStr;
 use zellij_tile::prelude::*;
-use crate::state::Mode;
 
 pub fn render_instruction_tip(y: usize, max_cols: usize) {
-    if max_cols < 11 { return; }
+    if max_cols < 11 {
+        return;
+    }
     let text = "?: <Ctrl h>";
-    let text = Text::new(text)
-        .color_range(3, 3..11);
+    let text = Text::new(text).color_range(3, 3..11);
     print_text_with_coordinates(text, 0, y, Some(max_cols), None);
 }
 
 enum HelpTextSize {
     Small,
     Medium,
-    Large
+    Large,
 }
 
 fn render_help_text(bind: &str, desc: &str, max_cols: usize, y: usize) {
@@ -56,7 +57,7 @@ pub fn render_instruction_line(max_cols: usize) {
     let desc = match text_size {
         HelpTextSize::Large => "Toggle hidden files",
         HelpTextSize::Medium => "hidden",
-        _ => ""
+        _ => "",
     };
     render_help_text(bind, desc, max_cols, 2);
 
@@ -64,7 +65,7 @@ pub fn render_instruction_line(max_cols: usize) {
     let desc = match text_size {
         HelpTextSize::Large => "Rename / move file",
         HelpTextSize::Medium => "rename",
-        _ => ""
+        _ => "",
     };
     render_help_text(bind, desc, max_cols, 3);
 
@@ -72,7 +73,7 @@ pub fn render_instruction_line(max_cols: usize) {
     let desc = match text_size {
         HelpTextSize::Large => "Delete file",
         HelpTextSize::Medium => "delete",
-        _ => ""
+        _ => "",
     };
     render_help_text(bind, desc, max_cols, 4);
 
@@ -80,7 +81,7 @@ pub fn render_instruction_line(max_cols: usize) {
     let desc = match text_size {
         HelpTextSize::Large => "Copy & paste file",
         HelpTextSize::Medium => "copy",
-        _ => ""
+        _ => "",
     };
     render_help_text(bind, desc, max_cols, 5);
 
@@ -88,7 +89,7 @@ pub fn render_instruction_line(max_cols: usize) {
     let desc = match text_size {
         HelpTextSize::Large => "Create new file",
         HelpTextSize::Medium => "create",
-        _ => ""
+        _ => "",
     };
     render_help_text(bind, desc, max_cols, 6);
 }
@@ -145,7 +146,7 @@ pub fn render_search_term(search_term: &str, mode: &Mode) {
         Mode::Copy => "PASTE: ",
         Mode::Delete => "CONFIRM (y): ",
         Mode::Move => "EDIT: ",
-        _ => "FIND: "
+        _ => "FIND: ",
     };
     let text = Text::new(format!("{}{}_", prompt, search_term))
         .color_range(2, 0..prompt.len())

--- a/default-plugins/strider/src/shared.rs
+++ b/default-plugins/strider/src/shared.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use unicode_width::UnicodeWidthStr;
 use zellij_tile::prelude::*;
+use crate::state::Mode;
 
 pub fn render_instruction_tip(y: usize, max_cols: usize) {
     if max_cols < 11 { return; }
@@ -58,6 +59,38 @@ pub fn render_instruction_line(max_cols: usize) {
         _ => ""
     };
     render_help_text(bind, desc, max_cols, 2);
+
+    let bind = "<Ctrl r>";
+    let desc = match text_size {
+        HelpTextSize::Large => "Rename / move file",
+        HelpTextSize::Medium => "rename",
+        _ => ""
+    };
+    render_help_text(bind, desc, max_cols, 3);
+
+    let bind = "<Ctrl d>";
+    let desc = match text_size {
+        HelpTextSize::Large => "Delete file",
+        HelpTextSize::Medium => "delete",
+        _ => ""
+    };
+    render_help_text(bind, desc, max_cols, 4);
+
+    let bind = "<Ctrl y>";
+    let desc = match text_size {
+        HelpTextSize::Large => "Copy & paste file",
+        HelpTextSize::Medium => "copy",
+        _ => ""
+    };
+    render_help_text(bind, desc, max_cols, 4);
+
+    let bind = "<Ctrl a>";
+    let desc = match text_size {
+        HelpTextSize::Large => "Create new file",
+        HelpTextSize::Medium => "create",
+        _ => ""
+    };
+    render_help_text(bind, desc, max_cols, 4);
 }
 
 pub fn render_list_tip(y: usize, max_cols: usize) {
@@ -106,8 +139,14 @@ pub fn calculate_list_bounds(
     }
 }
 
-pub fn render_search_term(search_term: &str) {
-    let prompt = "FIND: ";
+pub fn render_search_term(search_term: &str, mode: &Mode) {
+    let prompt = match mode {
+        Mode::Create => "CREATE: ",
+        Mode::Copy => "PASTE: ",
+        Mode::Delete => "CONFIRM (y): ",
+        Mode::Move => "EDIT: ",
+        _ => "FIND: "
+    };
     let text = Text::new(format!("{}{}_", prompt, search_term))
         .color_range(2, 0..prompt.len())
         .color_range(3, prompt.len()..);

--- a/default-plugins/strider/src/shared.rs
+++ b/default-plugins/strider/src/shared.rs
@@ -2,6 +2,14 @@ use std::path::PathBuf;
 use unicode_width::UnicodeWidthStr;
 use zellij_tile::prelude::*;
 
+pub fn render_instruction_tip(y: usize, max_cols: usize) {
+    if max_cols < 11 { return; }
+    let text = "?: <Ctrl h>";
+    let text = Text::new(text)
+        .color_range(3, 3..11);
+    print_text_with_coordinates(text, 0, y, Some(max_cols), None);
+}
+
 pub fn render_instruction_line(y: usize, max_cols: usize) {
     if max_cols > 78 {
         let text = "Help: go back with <Ctrl c>, go to root with /, <Ctrl e> - toggle hidden files";

--- a/default-plugins/strider/src/shared.rs
+++ b/default-plugins/strider/src/shared.rs
@@ -10,19 +10,54 @@ pub fn render_instruction_tip(y: usize, max_cols: usize) {
     print_text_with_coordinates(text, 0, y, Some(max_cols), None);
 }
 
+enum HelpTextSize {
+    Small,
+    Medium,
+    Large
+}
+
+fn render_help_text(bind: &str, desc: &str, max_cols: usize, y: usize) {
+    let len = bind.len();
+    let padding = " ".repeat(max_cols.saturating_sub(len + desc.len()));
+    let text = format!("{}{}{}", bind, padding, desc);
+    let text = Text::new(text).color_range(3, 0..len);
+    print_text_with_coordinates(text, 0, y, Some(max_cols), None)
+}
+
 pub fn render_instruction_line(max_cols: usize) {
-    let text = Text::new("Go back <Ctrl c>")
-        .color_range(3, 13..20);
-    print_text_with_coordinates(text, 0, 0, Some(max_cols), None);
+    let text_size = if max_cols > 28 {
+        HelpTextSize::Large
+    } else if max_cols > 15 {
+        HelpTextSize::Medium
+    } else if max_cols > 8 {
+        HelpTextSize::Small
+    } else {
+        return;
+    };
 
+    let bind = "<Ctrl c>";
+    let desc = match text_size {
+        HelpTextSize::Large => "Go back",
+        HelpTextSize::Medium => "back",
+        _ => "",
+    };
+    render_help_text(bind, desc, max_cols, 0);
 
-    let text = Text::new("Go to root /")
-        .color_range(3, 3..5);
-    print_text_with_coordinates(text, 0, 1, Some(max_cols), None);
+    let bind = "/";
+    let desc = match text_size {
+        HelpTextSize::Large => "Go to root",
+        HelpTextSize::Medium => "root",
+        _ => "",
+    };
+    render_help_text(bind, desc, max_cols, 1);
 
-    let text = Text::new("Toggle hidden files <Ctrl e>")
-        .color_range(3, 3..5);
-    print_text_with_coordinates(text, 0, 2, Some(max_cols), None);
+    let bind = "<Ctrl e>";
+    let desc = match text_size {
+        HelpTextSize::Large => "Toggle hidden files",
+        HelpTextSize::Medium => "hidden",
+        _ => ""
+    };
+    render_help_text(bind, desc, max_cols, 2);
 }
 
 pub fn render_list_tip(y: usize, max_cols: usize) {

--- a/default-plugins/strider/src/state.rs
+++ b/default-plugins/strider/src/state.rs
@@ -56,11 +56,17 @@ impl State {
     }
     pub fn handle_backspace(&mut self) {
         if self.search_term.is_empty() {
-            self.descend_to_previous_path();
+            match self.mode {
+                Mode::Normal | Mode::Searching => self.descend_to_previous_path(),
+                _ => {}
+            }
         } else {
             self.search_term.pop();
             if self.search_term.is_empty() {
-                self.mode = Mode::Normal;
+                match self.mode {
+                    Mode::Searching => self.mode = Mode::Normal,
+                    _ => {}
+                }
             }
             self.search_view
                 .update_search_results(&self.search_term, &self.file_list_view.files);
@@ -73,8 +79,8 @@ impl State {
             self.search_term.clear();
             self.search_view
                 .update_search_results(&self.search_term, &self.file_list_view.files);
-            self.mode = Mode::Normal;
         }
+        self.mode = Mode::Normal;
     }
     pub fn move_selection_up(&mut self) {
         match self.mode {
@@ -238,16 +244,24 @@ impl State {
         self.clear_search_term_or_descend(); // resets mode to Normal
     }
     fn handle_file_create(&self, target: PathBuf) {
-        let _ = std::fs::create_dir(target);
+        if let Err(err) = std::fs::create_dir(target) {
+            dbg!("Could not create file: {:?}", err);
+        }
     }
     fn handle_file_copy(&self, source: PathBuf, target: PathBuf) {
-        let _ = std::fs::copy(source, target);
+        if let Err(err) = std::fs::copy(source, target) {
+            dbg!("Cound not copy file: {:?}", err);
+        }
     }
     fn handle_file_move(&mut self, source: PathBuf, target: PathBuf) {
-        let _ = std::fs::rename(source, target);
+        if let Err(err) = std::fs::rename(source, target) {
+            dbg!("Cound not rename file: {:?}", err);
+        }
     }
     fn handle_file_delete(&self, source: PathBuf) {
-        let _ = std::fs::remove_file(source);
+        if let Err(err) = std::fs::remove_file(source) {
+            dbg!("Cound not delete file: {:?}", err);
+        }
     }
 }
 

--- a/default-plugins/strider/src/state.rs
+++ b/default-plugins/strider/src/state.rs
@@ -229,13 +229,25 @@ impl State {
         src.push(entry.get_pathbuf_without_root_prefix());
 
         match self.mode {
-            Mode::Create => unimplemented!(),
-            Mode::Copy => unimplemented!(),
-            Mode::Move => unimplemented!(),
-            Mode::Delete => unimplemented!(),
+            Mode::Create => self.handle_file_create(target),
+            Mode::Copy => self.handle_file_copy(src, target),
+            Mode::Move => self.handle_file_move(src, target),
+            Mode::Delete => self.handle_file_delete(src),
             _ => {}
-        }
+        };
         self.clear_search_term_or_descend(); // resets mode to Normal
+    }
+    fn handle_file_create(&self, target: PathBuf) {
+        let _ = std::fs::create_dir(target);
+    }
+    fn handle_file_copy(&self, source: PathBuf, target: PathBuf) {
+        let _ = std::fs::copy(source, target);
+    }
+    fn handle_file_move(&mut self, source: PathBuf, target: PathBuf) {
+        let _ = std::fs::rename(source, target);
+    }
+    fn handle_file_delete(&self, source: PathBuf) {
+        let _ = std::fs::remove_file(source);
     }
 }
 

--- a/default-plugins/strider/src/state.rs
+++ b/default-plugins/strider/src/state.rs
@@ -231,7 +231,7 @@ impl State {
             Mode::Delete => unimplemented!(),
             _ => {}
         }
-        self.mode = Mode::Normal;
+        self.clear_search_term_or_descend(); // resets mode to Normal
     }
 }
 

--- a/default-plugins/strider/src/state.rs
+++ b/default-plugins/strider/src/state.rs
@@ -9,12 +9,16 @@ use zellij_tile::prelude::*;
 
 pub const ROOT: &str = "/host";
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub enum Mode {
     #[default] Normal,
     // Loading,
     Searching,
-    Keybinds
+    Keybinds,
+    Create,
+    Copy,
+    Delete,
+    Move
 }
 
 #[derive(Default)]
@@ -77,6 +81,18 @@ impl State {
         match self.mode {
             Mode::Searching => self.search_view.move_selection_down(),
             _ => self.file_list_view.move_selection_down()
+        }
+    }
+    pub fn move_entry_to_search(&mut self) {
+        let entry = match self.mode {
+            Mode::Searching => self.search_view.get_selected_entry(),
+            _ => self.file_list_view.get_selected_entry()
+        };
+
+        if let Some(entry) = entry {
+            self.search_term = match entry {
+                FsEntry::Dir(path) | FsEntry::File(path, _) => path.display().to_string()
+            };
         }
     }
     pub fn handle_left_click(&mut self, line: isize) {
@@ -197,6 +213,17 @@ impl State {
             },
             _ => {},
         }
+    }
+
+    pub fn handle_file_manipulation(&mut self) {
+        match self.mode {
+            Mode::Create => unimplemented!(),
+            Mode::Copy => unimplemented!(),
+            Mode::Move => unimplemented!(),
+            Mode::Delete => unimplemented!(),
+            _ => {}
+        }
+        self.mode = Mode::Normal;
     }
 }
 

--- a/default-plugins/strider/src/state.rs
+++ b/default-plugins/strider/src/state.rs
@@ -97,10 +97,7 @@ impl State {
     }
     pub fn move_entry_to_search(&mut self) {
         if let Some(entry) = self.get_selected_entry() {
-            self.search_term = match entry {
-                FsEntry::Dir(path) | FsEntry::File(path, _) => path.display().to_string()
-            };
-            self.search_term = self.search_term[6..].to_string();
+            self.search_term = entry.get_pathbuf_without_root_prefix().display().to_string();
         }
     }
     pub fn handle_left_click(&mut self, line: isize) {
@@ -224,6 +221,13 @@ impl State {
     }
 
     pub fn handle_file_manipulation(&mut self) {
+        let mut target = self.initial_cwd.clone();
+        target.push(&self.search_term);
+
+        let mut src = self.initial_cwd.clone();
+        let entry = self.get_selected_entry().expect("Expected a selected entry");
+        src.push(entry.get_pathbuf_without_root_prefix());
+
         match self.mode {
             Mode::Create => unimplemented!(),
             Mode::Copy => unimplemented!(),

--- a/default-plugins/strider/src/state.rs
+++ b/default-plugins/strider/src/state.rs
@@ -88,16 +88,19 @@ impl State {
             _ => self.file_list_view.move_selection_down()
         }
     }
-    pub fn move_entry_to_search(&mut self) {
+    pub fn get_selected_entry(&mut self) -> Option<FsEntry> {
         let entry = match self.mode {
             Mode::Searching => self.search_view.get_selected_entry(),
             _ => self.file_list_view.get_selected_entry()
         };
-
-        if let Some(entry) = entry {
+        return entry;
+    }
+    pub fn move_entry_to_search(&mut self) {
+        if let Some(entry) = self.get_selected_entry() {
             self.search_term = match entry {
                 FsEntry::Dir(path) | FsEntry::File(path, _) => path.display().to_string()
             };
+            self.search_term = self.search_term[6..].to_string();
         }
     }
     pub fn handle_left_click(&mut self, line: isize) {

--- a/default-plugins/strider/src/state.rs
+++ b/default-plugins/strider/src/state.rs
@@ -238,7 +238,11 @@ impl State {
             Mode::Create => self.handle_file_create(target),
             Mode::Copy => self.handle_file_copy(src, target),
             Mode::Move => self.handle_file_move(src, target),
-            Mode::Delete => self.handle_file_delete(src),
+            Mode::Delete => {
+                if self.search_term == "y" {
+                    self.handle_file_delete(src);
+                }
+            },
             _ => {}
         };
         self.clear_search_term_or_descend(); // resets mode to Normal

--- a/default-plugins/strider/src/state.rs
+++ b/default-plugins/strider/src/state.rs
@@ -39,14 +39,19 @@ pub struct State {
 impl State {
     pub fn update_search_term(&mut self, character: char) {
         self.search_term.push(character);
-        if &self.search_term == ".." {
-            self.descend_to_previous_path();
-        } else if &self.search_term == "/" {
-            self.descend_to_root_path();
-        } else {
-            self.mode = Mode::Searching;
-            self.search_view
-                .update_search_results(&self.search_term, &self.file_list_view.files);
+        match self.mode {
+            Mode::Create | Mode::Copy | Mode::Delete | Mode::Move => return,
+            _ => {
+                if self.search_term == ".." {
+                    self.descend_to_previous_path();
+                } else if &self.search_term == "/" {
+                    self.descend_to_root_path();
+                } else {
+                    self.mode = Mode::Searching;
+                    self.search_view
+                        .update_search_results(&self.search_term, &self.file_list_view.files);
+                }
+            },
         }
     }
     pub fn handle_backspace(&mut self) {

--- a/default-plugins/strider/src/state.rs
+++ b/default-plugins/strider/src/state.rs
@@ -23,6 +23,7 @@ pub struct State {
     pub is_searching: bool,
     pub search_term: String,
     pub close_on_selection: bool,
+    pub showing_keybinds: bool,
 }
 
 impl State {

--- a/default-plugins/strider/src/state.rs
+++ b/default-plugins/strider/src/state.rs
@@ -254,23 +254,23 @@ impl State {
         self.clear_search_term_or_descend(); // resets mode to Normal
     }
     fn handle_file_create(&self, target: PathBuf) {
-        if let Err(err) = std::fs::create_dir(target) {
-            dbg!("Could not create file: {:?}", err);
+        if let Err(err) = std::fs::create_dir(&target) {
+            dbg!("Could not create {:?} file: {:?}", target, err);
         }
     }
     fn handle_file_copy(&self, source: PathBuf, target: PathBuf) {
-        if let Err(err) = std::fs::copy(source, target) {
-            dbg!("Cound not copy file: {:?}", err);
+        if let Err(err) = std::fs::copy(&source, &target) {
+            dbg!("Cound not copy file {:?} -> {:?}: {:?}", source, target, err);
         }
     }
     fn handle_file_move(&mut self, source: PathBuf, target: PathBuf) {
-        if let Err(err) = std::fs::rename(source, target) {
-            dbg!("Cound not rename file: {:?}", err);
+        if let Err(err) = std::fs::rename(&source, &target) {
+            dbg!("Cound not rename file {:?} -> {:?}: {:?}", source, target, err);
         }
     }
     fn handle_file_delete(&self, source: PathBuf) {
-        if let Err(err) = std::fs::remove_file(source) {
-            dbg!("Cound not delete file: {:?}", err);
+        if let Err(err) = std::fs::remove_file(&source) {
+            dbg!("Cound not delete {:?} file: {:?}", source, err);
         }
     }
 }

--- a/default-plugins/strider/src/state.rs
+++ b/default-plugins/strider/src/state.rs
@@ -11,14 +11,15 @@ pub const ROOT: &str = "/host";
 
 #[derive(Default, Clone)]
 pub enum Mode {
-    #[default] Normal,
+    #[default]
+    Normal,
     // Loading,
     Searching,
     Keybinds,
     Create,
     Copy,
     Delete,
-    Move
+    Move,
 }
 
 #[derive(Default)]
@@ -33,7 +34,7 @@ pub struct State {
     pub initial_cwd: PathBuf, // TODO: get this from zellij
     pub search_term: String,
     pub close_on_selection: bool,
-    pub mode: Mode
+    pub mode: Mode,
 }
 
 impl State {
@@ -58,14 +59,14 @@ impl State {
         if self.search_term.is_empty() {
             match self.mode {
                 Mode::Normal | Mode::Searching => self.descend_to_previous_path(),
-                _ => {}
+                _ => {},
             }
         } else {
             self.search_term.pop();
             if self.search_term.is_empty() {
                 match self.mode {
                     Mode::Searching => self.mode = Mode::Normal,
-                    _ => {}
+                    _ => {},
                 }
             }
             self.search_view
@@ -85,25 +86,28 @@ impl State {
     pub fn move_selection_up(&mut self) {
         match self.mode {
             Mode::Searching => self.search_view.move_selection_up(),
-            _ => self.file_list_view.move_selection_up()
+            _ => self.file_list_view.move_selection_up(),
         };
     }
     pub fn move_selection_down(&mut self) {
         match self.mode {
             Mode::Searching => self.search_view.move_selection_down(),
-            _ => self.file_list_view.move_selection_down()
+            _ => self.file_list_view.move_selection_down(),
         }
     }
     pub fn get_selected_entry(&mut self) -> Option<FsEntry> {
         let entry = match self.mode {
             Mode::Searching => self.search_view.get_selected_entry(),
-            _ => self.file_list_view.get_selected_entry()
+            _ => self.file_list_view.get_selected_entry(),
         };
         return entry;
     }
     pub fn move_entry_to_search(&mut self) {
         if let Some(entry) = self.get_selected_entry() {
-            self.search_term = entry.get_pathbuf_without_root_prefix().display().to_string();
+            self.search_term = entry
+                .get_pathbuf_without_root_prefix()
+                .display()
+                .to_string();
         }
     }
     pub fn handle_left_click(&mut self, line: isize) {
@@ -135,7 +139,7 @@ impl State {
                     if prev_selected == self.file_list_view.selected() {
                         self.traverse_dir();
                     }
-                }
+                },
             }
         }
     }
@@ -156,7 +160,7 @@ impl State {
     pub fn traverse_dir(&mut self) {
         let entry = match self.mode {
             Mode::Searching => self.search_view.get_selected_entry(),
-            _ => self.file_list_view.get_selected_entry()
+            _ => self.file_list_view.get_selected_entry(),
         };
         if let Some(entry) = entry {
             match &entry {
@@ -231,7 +235,9 @@ impl State {
         target.push(&self.search_term);
 
         let mut src = self.initial_cwd.clone();
-        let entry = self.get_selected_entry().expect("Expected a selected entry");
+        let entry = self
+            .get_selected_entry()
+            .expect("Expected a selected entry");
         src.push(entry.get_pathbuf_without_root_prefix());
 
         match self.mode {
@@ -243,7 +249,7 @@ impl State {
                     self.handle_file_delete(src);
                 }
             },
-            _ => {}
+            _ => {},
         };
         self.clear_search_term_or_descend(); // resets mode to Normal
     }

--- a/default-plugins/strider/src/state.rs
+++ b/default-plugins/strider/src/state.rs
@@ -231,7 +231,9 @@ impl State {
     }
 
     pub fn handle_file_manipulation(&mut self) {
-        let src = self.get_selected_entry().expect("Expected a selected entry");
+        let src = self
+            .get_selected_entry()
+            .expect("Expected a selected entry");
         let mut target_path = PathBuf::from(ROOT);
         target_path.push(&self.search_term);
         let target = match self.mode {
@@ -240,9 +242,12 @@ impl State {
                 if src.is_folder() {
                     FsEntry::Dir(target_path)
                 } else {
-                    FsEntry::File(target_path, src.size().expect("Target file should have a size"))
+                    FsEntry::File(
+                        target_path,
+                        src.size().expect("Target file should have a size"),
+                    )
                 }
-            }
+            },
         };
 
         let result = match self.mode {
@@ -252,13 +257,21 @@ impl State {
             Mode::Delete => {
                 if self.search_term == "y" {
                     self.handle_file_delete(&src)
-                } else { Ok(()) }
+                } else {
+                    Ok(())
+                }
             },
             _ => Ok(()),
         };
 
         if let Err(err) = result {
-            dbg!("Unable to perform file manipulation", &self.mode, src, target, err);
+            dbg!(
+                "Unable to perform file manipulation",
+                &self.mode,
+                src,
+                target,
+                err
+            );
         }
 
         self.clear_search_term_or_descend(); // resets mode to Normal
@@ -286,7 +299,10 @@ impl State {
                 let target_entry_path = target_path.join(entry_path.file_name().unwrap());
 
                 if entry_path.is_dir() {
-                    self.handle_file_copy(&FsEntry::Dir(entry_path.clone()), &FsEntry::Dir(target_entry_path))?;
+                    self.handle_file_copy(
+                        &FsEntry::Dir(entry_path.clone()),
+                        &FsEntry::Dir(target_entry_path),
+                    )?;
                 } else {
                     std::fs::copy(&entry_path, &target_entry_path)?;
                 }

--- a/zellij-tile/src/ui_components/text.rs
+++ b/zellij-tile/src/ui_components/text.rs
@@ -21,7 +21,7 @@ impl Text {
     }
     pub fn selected(mut self) -> Self {
         self.selected = true;
-        self.color_range(1, ..)
+        self.color_range(2, ..)
     }
     pub fn color_indices(mut self, index_level: usize, mut indices: Vec<usize>) -> Self {
         self.pad_indices(index_level);

--- a/zellij-tile/src/ui_components/text.rs
+++ b/zellij-tile/src/ui_components/text.rs
@@ -21,7 +21,7 @@ impl Text {
     }
     pub fn selected(mut self) -> Self {
         self.selected = true;
-        self
+        self.color_range(1, ..)
     }
     pub fn color_indices(mut self, index_level: usize, mut indices: Vec<usize>) -> Self {
         self.pad_indices(index_level);


### PR DESCRIPTION
Inspired from [#585](https://github.com/zellij-org/zellij/issues/585)

The user can use their arrows keys to select a source file, use a key bind to enter one of the modes, and use the existing search bar to enter their target path. A list of keybinds can be seen with `[C-h]`.

![strider binds](https://github.com/zellij-org/zellij/assets/66448807/210e4260-a473-4d8b-bb8d-4e99c944cab1)